### PR TITLE
Multiple host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,28 @@ Another part can execute commands to any memcached server : get, set, delete, fl
 
 ### Install
 
+Single server setup
+
 Environments :  
-* **MEMCACHED_HOST** : Default address of a single server
-* **MEMCACHED_PORT** : Default port of a single server
+* **MEMCACHED_HOST** : Default address of the server
+* **MEMCACHED_PORT** : Default port of the server
 
 ```shell
 docker run --rm -p 8080:80 -e MEMCACHED_HOST='127.0.0.1' -e MEMCACHED_PORT='11211' hatamiarash7/memcached-admin:latest
+```
+
+Multiple server setup (using the `Default` cluster)
+
+Environments :  
+* **MEMCACHED_HOST** : Comma seperated hostname and optional port
+* **MEMCACHED_PORT** : Default port of the hostnames not having a port specified
+
+```shell
+docker run --rm -p 8080:80 -e MEMCACHED_HOST='127.0.0.1:11211,127.0.0.1:11212' hatamiarash7/memcached-admin:latest
+# or
+docker run --rm -p 8080:80 -e MEMCACHED_HOST='127.0.0.1,127.0.0.2' -e MEMCACHED_PORT='11211' hatamiarash7/memcached-admin:latest
+# or
+docker run --rm -p 8080:80 -e MEMCACHED_HOST='127.0.0.1:11212,127.0.0.1' -e MEMCACHED_PORT='11211' hatamiarash7/memcached-admin:latest
 ```
 
 You can define your cluster in **Configuration** section

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Another part can execute commands to any memcached server : get, set, delete, fl
 
 ### Install
 
-Single server setup
+#### Single server setup
 
 Environments :  
 * **MEMCACHED_HOST** : Default address of the server
@@ -47,7 +47,7 @@ Environments :
 docker run --rm -p 8080:80 -e MEMCACHED_HOST='127.0.0.1' -e MEMCACHED_PORT='11211' hatamiarash7/memcached-admin:latest
 ```
 
-Multiple server setup (using the `Default` cluster)
+#### Multiple server setup (using the `Default` cluster)
 
 Environments :  
 * **MEMCACHED_HOST** : Comma seperated hostname and optional port

--- a/app/Config/Memcache.php
+++ b/app/Config/Memcache.php
@@ -3,6 +3,28 @@
 $host = getenv('MEMCACHED_HOST') ? getenv('MEMCACHED_HOST') : '127.0.0.1';
 $port = getenv('MEMCACHED_PORT') ? getenv('MEMCACHED_PORT') : '11211';
 
+$servers = array(
+    'Default' => array(
+        $host . ':' . $port =>
+            array(
+                'hostname' => $host,
+                'port' => $port,
+            ),
+    ),
+);
+
+$hosts = explode(",", $host);
+
+if (count($hosts) > 1) {
+    $servers = [];
+    foreach ($hosts as $host) {
+        $servers['Default'][$host] = [
+            'hostname' => parse_url($host, PHP_URL_HOST) ?: $host,
+            'port' => parse_url($host, PHP_URL_PORT) ?: $port
+        ];
+    }
+}
+
 return array(
     'stats_api' => 'Server',
     'slabs_api' => 'Server',
@@ -18,15 +40,5 @@ return array(
     'hit_rate_alert' => '90',
     'eviction_alert' => '0',
     'file_path' => 'Temp/',
-    'servers' =>
-        array(
-            'Default' =>
-                array(
-                    $host . ':' . $port =>
-                        array(
-                            'hostname' => $host,
-                            'port' => $port,
-                        ),
-                ),
-        ),
+    'servers' => $servers
 );


### PR DESCRIPTION
This will add support for multiple memcached hosts. 

The same environment variables can be used, however `MEMCACHED_HOST` can now be a comma-seperated list of hosts, with or without port. If no port is specified per host, the `MEMCACHED_PORT` will be used for it or the default. 